### PR TITLE
Fixed construction of SortedDict.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: julia
 
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 DataStructures 0.5.1
 Polynomials 0.1.2
 Compat 0.19.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,20 @@
 environment:
   matrix:
     - platform: x86
-      julia: 0.4
-      link: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-    - platform: x86
       julia: 0.5
       link: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+    - platform: x86
+      julia: 0.6
+      link: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     - platform: x86
       julia: nightly
       link: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
     - platform: x64
-      julia: 0.4
-      link: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-    - platform: x64
       julia: 0.5
       link: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+    - platform: x64
+      julia: 0.6
+      link: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
     - platform: x64
       julia: nightly
       link: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -40,7 +40,7 @@ function _add{T1,M1,W,N,T2<:Poly}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2)
   vr    = v1+v2
   M     = typeof(vr)
 
-  cr  = SortedDict{Int,M,ForwardOrdering}()
+  cr  = SortedDict{Int,M}()
   sᵢ  = intersect(_keys(c1), _keys(c2))
   s₁  = setdiff(_keys(c1), sᵢ)
   s₂  = setdiff(_keys(c2), sᵢ)
@@ -63,7 +63,7 @@ end
 
 
 function -{T1,M1,W,N}(p::PolyMatrix{T1,M1,Val{W},N})
-  cr = SortedDict{Int,M1,ForwardOrdering}()
+  cr = SortedDict{Int,M1}()
   for (k,v) in coeffs(p)
     insert!(cr, k, -v)
   end
@@ -116,7 +116,7 @@ function _mulconv{T1,M1,W,T2,M2,N}(p1::PolyMatrix{T1,M1,Val{W},2},
   _,v2  = first(c2) # for polynomialmatrices it returns key value pair
   vr    = v1*v2
   M     = typeof(vr)
-  cr    = SortedDict{Int,M,ForwardOrdering}()
+  cr    = SortedDict{Int,M}()
 
   # find all new powers k1+k2 and corresponding k1, k2
   klist = Dict{Int,Vector{Tuple{Int,Int}}}()
@@ -144,7 +144,7 @@ function _mulconv{T1,M1,W,N,T2<:Poly}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2)
   v2    = first(c2) # for polynomialmatrices it returns key value pair
   vr    = v1*v2
   M     = typeof(vr)
-  cr    = SortedDict{Int,M,ForwardOrdering}()
+  cr    = SortedDict{Int,M}()
 
   # find all new powers k1+k2 and corresponding k1, k2
   klist = Dict{Int,Vector{Tuple{Int,Int}}}()
@@ -271,7 +271,7 @@ function _add{T1,M1,W,N,T2<:Number}(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2)
   c1    = coeffs(p1)
   _,v1  = first(c1)    # for polynomials first(c1) returns index of first element
   M     = typeof(similar(v1, T))
-  cr    = SortedDict{Int,M,ForwardOrdering}()
+  cr    = SortedDict{Int,M}()
 
   for (k1,v1) in coeffs(p1)
     insert!(cr, k1, v1)
@@ -291,7 +291,7 @@ function _mul{T1,M1,W,N,T2<:Number}(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2)
   c1    = coeffs(p1)
   _,v1  = first(c1) # for polynomials first(c1) returns index of first element
   M     = typeof(similar(v1, T))
-  cr    = SortedDict{Int,M,ForwardOrdering}()
+  cr    = SortedDict{Int,M}()
 
   for (k1,v1) in coeffs(p1)
     insert!(cr, k1, v1*v2)

--- a/src/type.jl
+++ b/src/type.jl
@@ -89,7 +89,7 @@ end
 function PolyMatrix{T,N,W}(PM::AbstractArray{Poly{T},N}, ::Type{Val{W}})
   N <= 2 || error("PolyMatrix: higher order arrays not supported at this point")
   M = typeof(similar(PM, T)) # NOTE: Is there a more memory-efficient way to obtain M?
-  c = SortedDict(Dict{Int,M}())
+  c = SortedDict{Int,M}()
   # find the union of all index sets of all polynomials in the matrix PM
   S = Set{Int}()
   for p in PM
@@ -134,7 +134,7 @@ function PolyMatrix{M<:AbstractArray,W}(A::M, dims::Tuple{Int}, ::Type{Val{W}})
     throw(DomainError())
   end
   p0 = dn > 0 ? p0 = A[1:ny] : zeros(eltype(A), dims)
-  c  = SortedDict(Dict{Int,typeof(p0)}())
+  c  = SortedDict{Int,typeof(p0)}()
   insert!(c, 0, p0)
   for k = 1:dn-1
     p = A[k*ny+(1:ny)]
@@ -155,7 +155,7 @@ function PolyMatrix{M<:AbstractArray,W}(A::M, dims::Tuple{Int,Int}, ::Type{Val{W
     throw(DomainError())
   end
   p0 = dn > 0 ? A[1:ny, :] : zeros(eltype(A),dims)
-  c  = SortedDict(Dict{Int,typeof(p0)}())
+  c  = SortedDict{Int,typeof(p0)}()
   for k = 0:dn-1
     idx = reverse ? (dn-k-1)*ny+(1:ny) : k*ny+(1:ny)
     v = A[idx, :]
@@ -175,7 +175,7 @@ function PolyMatrix{M<:AbstractArray,W}(A::M, dims::Tuple{Int,Int,Int}, ::Type{V
   end
   dn = dims[3]
   p0 = A[:, :, 1]
-  c  = SortedDict(Dict{Int,typeof(p0)}())
+  c  = SortedDict{Int,typeof(p0)}()
   insert!(c, 0, p0)
   for k = 1:dn-1
     p = A[:, :, k+1]


### PR DESCRIPTION
The constructionof SortedDict is now more uniform across the package.
It relies on the default ordering being ForwardOrdering.