### PR TITLE
Upgrade to Julia v1

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ DataStructures 0.5.2
 Polynomials 0.1.2
 Compat 0.19.0
 DSP
+FFTW

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.5
+julia 0.7
 DataStructures 0.5.2
 Polynomials 0.1.2
 Compat 0.19.0
-DSP 
+DSP

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 DataStructures 0.5.2
 Polynomials 0.1.2
 Compat 0.19.0
+DSP 

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -5,6 +5,7 @@ module PolynomialMatrices
 using DataStructures
 using Polynomials
 using Compat
+using LinearAlgebra
 
 # Import functions for overloading
 import Polynomials: coeffs, degree, variable

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -7,6 +7,7 @@ using Polynomials
 using Compat
 using LinearAlgebra
 using DSP
+using SparseArrays
 
 # Import functions for overloading
 import Polynomials: coeffs, degree, variable

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -8,6 +8,7 @@ using Compat
 using LinearAlgebra
 using DSP
 using SparseArrays
+using FFTW
 
 # Import functions for overloading
 import Polynomials: coeffs, degree, variable

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -17,13 +17,13 @@ import Base: promote_rule, convert, size, length
 import Base: +, -, *, /, inv
 import Base: getindex, setindex!, eltype, similar
 import Base: copy
-import Base: transpose, ctranspose
+import Base: transpose, adjoint
 import Base: summary
 import Base: insert!
 import Base: checkbounds
 import Compat.view
 import Base: isapprox, ==, isequal, hash
-import LinearAlgebra: det, norm, vecnorm, rank
+import LinearAlgebra: det, norm, rank
 import DSP: filt!, filt
 
 # Export

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -11,7 +11,7 @@ using LinearAlgebra
 import Polynomials: coeffs, degree, variable
 import Base: start, next, done
 import Base: promote_rule, convert, size, length
-import Base: +, -, *, /, inv, det
+import Base: +, -, *, /, inv
 import Base: getindex, setindex!, eltype, similar
 import Base: copy
 import Base: transpose, ctranspose
@@ -20,7 +20,8 @@ import Base: insert!
 import Base: checkbounds
 import Base: filt!, filt
 import Compat.view
-import Base: vecnorm, norm, rank, isapprox, ==, isequal, hash
+import Base: isapprox, ==, isequal, hash
+import LinearAlgebra: det, norm, vecnorm, rank
 
 # Export
 export PolyMatrix

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -6,6 +6,7 @@ using DataStructures
 using Polynomials
 using Compat
 using LinearAlgebra
+using DSP
 
 # Import functions for overloading
 import Polynomials: coeffs, degree, variable
@@ -20,7 +21,8 @@ import Base: insert!
 import Base: checkbounds
 import Compat.view
 import Base: isapprox, ==, isequal, hash
-import LinearAlgebra: det, norm, vecnorm, rank, filt!, filt
+import LinearAlgebra: det, norm, vecnorm, rank
+import DSP: filt!, filt
 
 # Export
 export PolyMatrix

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -12,7 +12,6 @@ using FFTW
 
 # Import functions for overloading
 import Polynomials: coeffs, degree, variable
-import Base: start, next, done
 import Base: promote_rule, convert, size, length
 import Base: +, -, *, /, inv
 import Base: getindex, setindex!, eltype, similar

--- a/src/PolynomialMatrices.jl
+++ b/src/PolynomialMatrices.jl
@@ -18,10 +18,9 @@ import Base: transpose, ctranspose
 import Base: summary
 import Base: insert!
 import Base: checkbounds
-import Base: filt!, filt
 import Compat.view
 import Base: isapprox, ==, isequal, hash
-import LinearAlgebra: det, norm, vecnorm, rank
+import LinearAlgebra: det, norm, vecnorm, rank, filt!, filt
 
 # Export
 export PolyMatrix

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -131,7 +131,7 @@ function _mulconv(p1::PolyMatrix{T1,M1,Val{W},2},
   return PolyMatrix(cr, size(vr), Val{W})
 end
 
-_mulconv{T1,M1,W,N,T2<:Poly}(p1::T2, p2::PolyMatrix{T1,M1,Val{W},N}) = _mulconv(p2,p1)
+_mulconv(p1::T2, p2::PolyMatrix{T1,M1,Val{W},N}) where {T1,M1,W,N,T2<:Poly} = _mulconv(p2,p1)
 
 function _mulconv(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:Poly}
   # figure out return type
@@ -162,8 +162,8 @@ function _mulconv(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:P
   return PolyMatrix(cr, size(vr), Val{W})
 end
 
-_keys{T}(c::T) = keys(c)
-_keys{T<:AbstractArray}(c::T) = eachindex(c)-1
+_keys(c::T) where {T} = keys(c)
+_keys(c::T) where {T<:AbstractArray} = eachindex(c)-1
 
 function _mulfft(p1::PolyMatrix{T1,M1,Val{W},2},
   p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,T2,M2,N}
@@ -192,7 +192,7 @@ function _mulfft(p1::PolyMatrix{T1,M1,Val{W},2},
   return PolyMatrix(ar, Val{W})
 end
 
-_mulfft{T1,M1,W,N,T2}(p1::Poly{T2}, p2::PolyMatrix{T1,M1,Val{W},N}) = _mulfft(p2,p1)
+_mulfft(p1::Poly{T2}, p2::PolyMatrix{T1,M1,Val{W},N}) where {T1,M1,W,N,T2} = _mulfft(p2,p1)
 
 function _mulfft(p1::PolyMatrix{T1,M1,Val{W},N}, p2::Poly{T2}) where {T1,M1,W,N,T2}
   T     = promote_type(T1, T2)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,7 +1,7 @@
-## Basic operations between polynomial matrices
+zero## Basic operations between polynomial matrices
 function +(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,N,T2,M2}
   if size(p1) ≠ size(p2)
-    warn("+(p1,p2): size(p1) ≠ size(p2)")
+    @warn "+(p1,p2): size(p1) ≠ size(p2)"
     throw(DomainError())
   end
   _add(p1,p2)
@@ -16,7 +16,7 @@ function _add(p1::PolyMatrix{T1,M1,Val{W},N},
   vr    = v1+v2
   M     = typeof(vr)
 
-  cr  = SortedDict(0=>zeros(vr))
+  cr  = SortedDict(0=>zero(vr))
   sᵢ  = intersect(keys(c1), keys(c2))
   s₁  = setdiff(keys(c1), sᵢ)
   s₂  = setdiff(keys(c2), sᵢ)
@@ -37,7 +37,7 @@ function _add(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:Poly}
   c2    = coeffs(p2)
   _,v1  = first(c1) # for polynomials first(c1) returns index of first element
   v2    = first(c2)   # for polynomialmatrices it returns key value pair
-  vr    = v1+v2
+  vr    = v1 .+ v2
   M     = typeof(vr)
 
   cr  = SortedDict(Dict{Int,M}())
@@ -51,13 +51,13 @@ function _add(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:Poly}
     insert!(cr, k, p2[k])
   end
   for k in sᵢ
-    insert!(cr, k, c1[k]+p2[k])
+    insert!(cr, k, c1[k] .+ p2[k])
   end
   return PolyMatrix(cr, size(vr), Val{W})
 end
 
 function +(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2}
-  warn("p1+p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables")
+  @warn "p1+p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables"
   throw(DomainError())
 end
 
@@ -73,14 +73,14 @@ end
 -(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,N,T2,M2} = +(p1,-p2)
 
 function -(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2}
-  warn("p1-p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables")
+  @warn "p1-p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables"
   throw(DomainError())
 end
 
 # heuristic used below was found by benchmarking
 function *(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,Val{W},2}) where {T1,M1,W,T2,M2}
   if size(p1,2) ≠ size(p2,1)
-    warn("*(p1,p2): size(p1,2) ≠ size(p2,1)")
+    @warn "*(p1,p2): size(p1,2) ≠ size(p2,1)"
     throw(DomainError())
   end
   _mul(p1,p2)
@@ -88,7 +88,7 @@ end
 
 function *(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,Val{W},1}) where {T1,M1,W,T2,M2}
   if size(p1,2) ≠ size(p2,1)
-    warn("*(p1,p2): size(p1,2) ≠ size(p2,1)")
+    @warn "*(p1,p2): size(p1,2) ≠ size(p2,1)"
     throw(DomainError())
   end
   _mul(p1,p2)
@@ -122,7 +122,7 @@ function _mulconv(p1::PolyMatrix{T1,M1,Val{W},2},
 
   # do the calculations
   for k in keys(klist)
-    vk = zeros(vr)
+    vk = zero(vr)
     for v in klist[k]
       vk += c1[v[1]]*c2[v[2]]
     end
@@ -163,7 +163,7 @@ function _mulconv(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:P
 end
 
 _keys(c::T) where {T} = keys(c)
-_keys(c::T) where {T<:AbstractArray} = eachindex(c)-1
+_keys(c::T) where {T<:AbstractArray} = eachindex(c) .- 1
 
 function _mulfft(p1::PolyMatrix{T1,M1,Val{W},2},
   p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,T2,M2,N}
@@ -238,7 +238,7 @@ function _fftmatrix(p::Poly{T1}, ::Type{T}, dn::Integer) where {T1,T}
 end
 
 function *(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2}
-  warn("p1*p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables")
+  @warn "p1*p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables"
   throw(DomainError())
 end
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,5 +1,5 @@
 ## Basic operations between polynomial matrices
-function +{T1,M1,W,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2,Val{W},N})
+function +(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,N,T2,M2}
   if size(p1) ≠ size(p2)
     warn("+(p1,p2): size(p1) ≠ size(p2)")
     throw(DomainError())
@@ -7,8 +7,8 @@ function +{T1,M1,W,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2
   _add(p1,p2)
 end
 
-function _add{T1,M1,W,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},N},
-  p2::PolyMatrix{T2,M2,Val{W},N})
+function _add(p1::PolyMatrix{T1,M1,Val{W},N},
+  p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,N,T2,M2}
   c1    = coeffs(p1)
   c2    = coeffs(p2)
   _,v1  = first(c1)
@@ -32,7 +32,7 @@ function _add{T1,M1,W,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},N},
   return PolyMatrix(cr, size(vr), Val{W})
 end
 
-function _add{T1,M1,W,N,T2<:Poly}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2)
+function _add(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:Poly}
   c1    = coeffs(p1)
   c2    = coeffs(p2)
   _,v1  = first(c1) # for polynomials first(c1) returns index of first element
@@ -56,13 +56,13 @@ function _add{T1,M1,W,N,T2<:Poly}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2)
   return PolyMatrix(cr, size(vr), Val{W})
 end
 
-function +{T1,M1,W1,W2,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N})
+function +(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2}
   warn("p1+p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables")
   throw(DomainError())
 end
 
 
-function -{T1,M1,W,N}(p::PolyMatrix{T1,M1,Val{W},N})
+function -(p::PolyMatrix{T1,M1,Val{W},N}) where {T1,M1,W,N}
   cr = SortedDict(Dict{Int,M1}())
   for (k,v) in coeffs(p)
     insert!(cr, k, -v)
@@ -70,15 +70,15 @@ function -{T1,M1,W,N}(p::PolyMatrix{T1,M1,Val{W},N})
   return PolyMatrix(cr, size(p), Val{W})
 end
 
--{T1,M1,W,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2,Val{W},N}) = +(p1,-p2)
+-(p1::PolyMatrix{T1,M1,Val{W},N}, p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,N,T2,M2} = +(p1,-p2)
 
-function -{T1,M1,W1,W2,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N})
+function -(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2}
   warn("p1-p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables")
   throw(DomainError())
 end
 
 # heuristic used below was found by benchmarking
-function *{T1,M1,W,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,Val{W},2})
+function *(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,Val{W},2}) where {T1,M1,W,T2,M2}
   if size(p1,2) ≠ size(p2,1)
     warn("*(p1,p2): size(p1,2) ≠ size(p2,1)")
     throw(DomainError())
@@ -86,7 +86,7 @@ function *{T1,M1,W,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,V
   _mul(p1,p2)
 end
 
-function *{T1,M1,W,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,Val{W},1})
+function *(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,Val{W},1}) where {T1,M1,W,T2,M2}
   if size(p1,2) ≠ size(p2,1)
     warn("*(p1,p2): size(p1,2) ≠ size(p2,1)")
     throw(DomainError())
@@ -94,7 +94,7 @@ function *{T1,M1,W,T2,M2}(p1::PolyMatrix{T1,M1,Val{W},2}, p2::PolyMatrix{T2,M2,V
   _mul(p1,p2)
 end
 
-function _mul{T1,T2}(p1::T1, p2::T2)
+function _mul(p1::T1, p2::T2) where {T1,T2}
   degree_cutoff = 45
   if degree(p1)+degree(p2) > degree_cutoff
     return _mulfft(p1,p2)
@@ -103,8 +103,8 @@ function _mul{T1,T2}(p1::T1, p2::T2)
   end
 end
 
-function _mulconv{T1,M1,W,T2,M2,N}(p1::PolyMatrix{T1,M1,Val{W},2},
-  p2::PolyMatrix{T2,M2,Val{W},N})
+function _mulconv(p1::PolyMatrix{T1,M1,Val{W},2},
+  p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,T2,M2,N}
   # figure out return type
   c1    = coeffs(p1)
   c2    = coeffs(p2)
@@ -133,7 +133,7 @@ end
 
 _mulconv{T1,M1,W,N,T2<:Poly}(p1::T2, p2::PolyMatrix{T1,M1,Val{W},N}) = _mulconv(p2,p1)
 
-function _mulconv{T1,M1,W,N,T2<:Poly}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2)
+function _mulconv(p1::PolyMatrix{T1,M1,Val{W},N}, p2::T2) where {T1,M1,W,N,T2<:Poly}
   # figure out return type
   c1    = coeffs(p1)
   c2    = coeffs(p2)
@@ -165,8 +165,8 @@ end
 _keys{T}(c::T) = keys(c)
 _keys{T<:AbstractArray}(c::T) = eachindex(c)-1
 
-function _mulfft{T1,M1,W,T2,M2,N}(p1::PolyMatrix{T1,M1,Val{W},2},
-  p2::PolyMatrix{T2,M2,Val{W},N})
+function _mulfft(p1::PolyMatrix{T1,M1,Val{W},2},
+  p2::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,T2,M2,N}
   T     = promote_type(T1, T2)
   c1    = coeffs(p1)
   c2    = coeffs(p2)
@@ -194,7 +194,7 @@ end
 
 _mulfft{T1,M1,W,N,T2}(p1::Poly{T2}, p2::PolyMatrix{T1,M1,Val{W},N}) = _mulfft(p2,p1)
 
-function _mulfft{T1,M1,W,N,T2}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::Poly{T2})
+function _mulfft(p1::PolyMatrix{T1,M1,Val{W},N}, p2::Poly{T2}) where {T1,M1,W,N,T2}
   T     = promote_type(T1, T2)
   c1    = coeffs(p1)
   c2    = coeffs(p2)
@@ -220,7 +220,7 @@ function _mulfft{T1,M1,W,N,T2}(p1::PolyMatrix{T1,M1,Val{W},N}, p2::Poly{T2})
   return PolyMatrix(ar, Val{W})
 end
 
-function _fftmatrix{T1,M1,W1,N,T}(p::PolyMatrix{T1,M1,Val{W1},N}, ::Type{T}, dn::Integer)
+function _fftmatrix(p::PolyMatrix{T1,M1,Val{W1},N}, ::Type{T}, dn::Integer) where {T1,M1,W1,N,T}
   A = zeros(T, size(p)..., dn)
   for (k,v) in coeffs(p)
     A[:,:,k+1] = v
@@ -228,7 +228,7 @@ function _fftmatrix{T1,M1,W1,N,T}(p::PolyMatrix{T1,M1,Val{W1},N}, ::Type{T}, dn:
   A
 end
 
-function _fftmatrix{T1,T}(p::Poly{T1}, ::Type{T}, dn::Integer)
+function _fftmatrix(p::Poly{T1}, ::Type{T}, dn::Integer) where {T1,T}
   A = zeros(T,dn)
   c = coeffs(p)
   for i in eachindex(c)
@@ -237,35 +237,35 @@ function _fftmatrix{T1,T}(p::Poly{T1}, ::Type{T}, dn::Integer)
   A
 end
 
-function *{T1,M1,W1,W2,N,T2,M2}(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N})
+function *(p1::PolyMatrix{T1,M1,Val{W1},N}, p2::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2}
   warn("p1*p2: `p1` ($T1,$W1) and `p2` ($T2,$W2) have different variables")
   throw(DomainError())
 end
 
 ## Basic operations between polynomial matrices and AbstractArrays
-+{T,M1,W,N,M2<:AbstractArray}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = p1 + PolyMatrix(p2, Val{W})
-+{T,M1,W,N,M2<:AbstractArray}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = PolyMatrix(p1, Val{W}) + p2
++(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:AbstractArray} = p1 + PolyMatrix(p2, Val{W})
++(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:AbstractArray} = PolyMatrix(p1, Val{W}) + p2
 
--{T,M1,W,N,M2<:AbstractArray}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = p1 - PolyMatrix(p2, Val{W})
--{T,M1,W,N,M2<:AbstractArray}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = PolyMatrix(p1, Val{W}) - p2
+-(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:AbstractArray} = p1 - PolyMatrix(p2, Val{W})
+-(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:AbstractArray} = PolyMatrix(p1, Val{W}) - p2
 
-*{T,M1,W,N,S}(p1::PolyMatrix{T,M1,Val{W},N}, p2::AbstractArray{S,2}) = p1*PolyMatrix(p2, Val{W})
-*{T,M1,W,N,S}(p2::AbstractArray{S,2}, p1::PolyMatrix{T,M1,Val{W},N}) = PolyMatrix(p2, Val{W})*p1
+*(p1::PolyMatrix{T,M1,Val{W},N}, p2::AbstractArray{S,2}) where {T,M1,W,N,S} = p1*PolyMatrix(p2, Val{W})
+*(p2::AbstractArray{S,2}, p1::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,S} = PolyMatrix(p2, Val{W})*p1
 
-*{T,M1,W,N,S<:Number}(p1::PolyMatrix{T,M1,Val{W},N}, p2::AbstractArray{S,1}) = p1*PolyMatrix(p2, size(p2), Val{W})
+*(p1::PolyMatrix{T,M1,Val{W},N}, p2::AbstractArray{S,1}) where {T,M1,W,N,S<:Number} = p1*PolyMatrix(p2, size(p2), Val{W})
 
 ## Basic operations between polynomial matrices and polynomials
-+{T,M1,W,N,M2<:Poly}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _add(p1, p2)
-+{T,M1,W,N,M2<:Poly}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = _add(p2, p1)
++(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Poly} = _add(p1, p2)
++(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:Poly} = _add(p2, p1)
 
--{T,M1,W,N,M2<:Poly}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _add(p1, -p2)
--{T,M1,W,N,M2<:Poly}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = _add(-p2, p1)
+-(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Poly} = _add(p1, -p2)
+-(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:Poly} = _add(-p2, p1)
 
-*{T,M1,W,N,M2<:Poly}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _mul(p1, p2)
-*{T,M1,W,N,M2<:Poly}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = _mul(p2, p1)
+*(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Poly} = _mul(p1, p2)
+*(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:Poly} = _mul(p2, p1)
 
 ## Basic operations between polynomial matrices and Numbers
-function _add{T1,M1,W,N,T2<:Number}(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2)
+function _add(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2) where {T1,M1,W,N,T2<:Number}
   T     = promote_type(T1, T2)
   c1    = coeffs(p1)
   _,v1  = first(c1)    # for polynomials first(c1) returns index of first element
@@ -279,13 +279,13 @@ function _add{T1,M1,W,N,T2<:Number}(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2)
   return PolyMatrix(cr, size(p1), Val{W})
 end
 
-+{T,M1,W,N,M2<:Number}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _add(p1, p2)
-+{T,M1,W,N,M2<:Number}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = _add(p2, p1)
++(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Number} = _add(p1, p2)
++(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:Number} = _add(p2, p1)
 
--{T,M1,W,N,M2<:Number}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _add(p1, -p2)
--{T,M1,W,N,M2<:Number}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = _add(-p2, p1)
+-(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Number} = _add(p1, -p2)
+-(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:Number} = _add(-p2, p1)
 
-function _mul{T1,M1,W,N,T2<:Number}(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2)
+function _mul(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2) where {T1,M1,W,N,T2<:Number}
   T     = promote_type(T1, T2)
   c1    = coeffs(p1)
   _,v1  = first(c1) # for polynomials first(c1) returns index of first element
@@ -298,55 +298,55 @@ function _mul{T1,M1,W,N,T2<:Number}(p1::PolyMatrix{T1,M1,Val{W},N}, v2::T2)
   return PolyMatrix(cr, size(p1), Val{W})
 end
 
-*{T,M1,W,N,M2<:Number}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _mul(p1, p2)
-*{T,M1,W,N,M2<:Number}(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) = _mul(p2, p1)
+*(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Number} = _mul(p1, p2)
+*(p1::M2, p2::PolyMatrix{T,M1,Val{W},N}) where {T,M1,W,N,M2<:Number} = _mul(p2, p1)
 
-/{T,M1,W,N,M2<:Number}(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) = _mul(p1, 1/p2)
+/(p1::PolyMatrix{T,M1,Val{W},N}, p2::M2) where {T,M1,W,N,M2<:Number} = _mul(p1, 1/p2)
 
 # multiplication with abstractArray
 # transpose
-Base.LinAlg.At_mul_B{T1,M1,W,N1,T2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) = transpose(p1)*p2
+Base.LinAlg.At_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = transpose(p1)*p2
 
-Base.LinAlg.A_mul_Bt{T1,M1,W,N1,T2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) = p1*transpose(p2)
+Base.LinAlg.A_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = p1*transpose(p2)
 
-Base.LinAlg.At_mul_Bt{T1,M1,W,N1,T2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) = transpose(p1)*transpose(p2)
+Base.LinAlg.At_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = transpose(p1)*transpose(p2)
 
 # ctranspose
-Base.LinAlg.Ac_mul_B{T1,M1,W,N1,T2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) = ctranspose(p1)*p2
+Base.LinAlg.Ac_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = ctranspose(p1)*p2
 
-Base.LinAlg.A_mul_Bc{T1,M1,W,N1,T2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) = p1*ctranspose(p2)
+Base.LinAlg.A_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = p1*ctranspose(p2)
 
-Base.LinAlg.Ac_mul_Bc{T1,M1,W,N1,T2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) = ctranspose(p1)*ctranspose(p2)
+Base.LinAlg.Ac_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = ctranspose(p1)*ctranspose(p2)
 
 # multiplication between Polynomialmatrices
 # transpose
-Base.LinAlg.At_mul_B{T1,M1,W,N1,T2,M2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) = transpose(p1)*p2
+Base.LinAlg.At_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = transpose(p1)*p2
 
-Base.LinAlg.A_mul_Bt{T1,M1,W,N1,T2,M2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) = p1*transpose(p2)
+Base.LinAlg.A_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = p1*transpose(p2)
 
-Base.LinAlg.At_mul_Bt{T1,M1,W,N1,T2,M2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) = transpose(p1)*transpose(p2)
+Base.LinAlg.At_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = transpose(p1)*transpose(p2)
 
 # ctranspose
-Base.LinAlg.Ac_mul_B{T1,M1,W,N1,T2,M2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) = ctranspose(p1)*p2
+Base.LinAlg.Ac_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = ctranspose(p1)*p2
 
-Base.LinAlg.A_mul_Bc{T1,M1,W,N1,T2,M2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) = p1*ctranspose(p2)
+Base.LinAlg.A_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = p1*ctranspose(p2)
 
-Base.LinAlg.Ac_mul_Bc{T1,M1,W,N1,T2,M2,N2}(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) = ctranspose(p1)*ctranspose(p2)
+Base.LinAlg.Ac_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = ctranspose(p1)*ctranspose(p2)
 
 # determinant
-function det{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
+function det(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
   size(p,1) == size(p,2) || throw(DimensionMismatch("det: PolyMatrix must be square"))
   n  = size(p,1)
   dn = (degree(p))*n+1
@@ -363,12 +363,12 @@ function det{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
   return Poly(ar, W)
 end
 
-function _truncate{T<:Real,T2}(::Type{T}, a::AbstractArray{T2})
+function _truncate(::Type{T}, a::AbstractArray{T2}) where {T<:Real,T2}
   r = similar(a, T)
   r = real(a)
 end
 
-function _truncate{T<:Integer,T2}(::Type{T}, a::AbstractArray{T2})
+function _truncate(::Type{T}, a::AbstractArray{T2}) where {T<:Integer,T2}
   r = similar(a, T)
   for i in eachindex(a)
     r[i] = convert(T, round(real(a[i])))
@@ -378,7 +378,7 @@ end
 
 # inversion
 # return determinant polynomial and adjugate polynomial matrix
-function inv{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
+function inv(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
   size(p,1) == size(p,2) || throw(DimensionMismatch("det: PolyMatrix must be square"))
   n  = size(p,1)
   dn = degree(p)*n+1

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -305,45 +305,45 @@ end
 
 # multiplication with abstractArray
 # transpose
-Base.LinAlg.At_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = transpose(p1)*p2
-
-Base.LinAlg.A_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = p1*transpose(p2)
-
-Base.LinAlg.At_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = transpose(p1)*transpose(p2)
-
-# ctranspose
-Base.LinAlg.Ac_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = ctranspose(p1)*p2
-
-Base.LinAlg.A_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = p1*ctranspose(p2)
-
-Base.LinAlg.Ac_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = ctranspose(p1)*ctranspose(p2)
-
-# multiplication between Polynomialmatrices
-# transpose
-Base.LinAlg.At_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = transpose(p1)*p2
-
-Base.LinAlg.A_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = p1*transpose(p2)
-
-Base.LinAlg.At_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = transpose(p1)*transpose(p2)
-
-# ctranspose
-Base.LinAlg.Ac_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = ctranspose(p1)*p2
-
-Base.LinAlg.A_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = p1*ctranspose(p2)
-
-Base.LinAlg.Ac_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
-  p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = ctranspose(p1)*ctranspose(p2)
+# Base.LinAlg.At_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = transpose(p1)*p2
+#
+# Base.LinAlg.A_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = p1*transpose(p2)
+#
+# Base.LinAlg.At_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = transpose(p1)*transpose(p2)
+#
+# # ctranspose
+# Base.LinAlg.Ac_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = ctranspose(p1)*p2
+#
+# Base.LinAlg.A_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = p1*ctranspose(p2)
+#
+# Base.LinAlg.Ac_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::AbstractArray{T2,N2}) where {T1,M1,W,N1,T2,N2} = ctranspose(p1)*ctranspose(p2)
+#
+# # multiplication between Polynomialmatrices
+# # transpose
+# Base.LinAlg.At_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = transpose(p1)*p2
+#
+# Base.LinAlg.A_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = p1*transpose(p2)
+#
+# Base.LinAlg.At_mul_Bt(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = transpose(p1)*transpose(p2)
+#
+# # ctranspose
+# Base.LinAlg.Ac_mul_B(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = ctranspose(p1)*p2
+#
+# Base.LinAlg.A_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = p1*ctranspose(p2)
+#
+# Base.LinAlg.Ac_mul_Bc(p1::PolyMatrix{T1,M1,Val{W},N1},
+#   p2::PolyMatrix{T2,M2,Val{W},N2}) where {T1,M1,W,N1,T2,M2,N2} = ctranspose(p1)*ctranspose(p2)
 
 # determinant
 function det(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,10 +1,10 @@
 # PolyMatrix and PolyMatrix
-promote_rule{T1,T2,M1,M2,W,N}(::Type{PolyMatrix{T1,M1,Val{W},N}},
-  ::Type{PolyMatrix{T2,M2,Val{W},N}}) =
+promote_rule(::Type{PolyMatrix{T1,M1,Val{W},N}},
+  ::Type{PolyMatrix{T2,M2,Val{W},N}}) where {T1,T2,M1,M2,W,N} =
   PolyMatrix{promote_type(T1, T2), promote_type(M1,M2), Val{W}, N}
 
-function _convert{T1,N,T2,M1,M2,W}(::Type{PolyMatrix{T1,M1,Val{W},N}},
-  p::PolyMatrix{T2,M2,Val{W},N})
+function _convert(::Type{PolyMatrix{T1,M1,Val{W},N}},
+  p::PolyMatrix{T2,M2,Val{W},N}) where {T1,N,T2,M1,M2,W}
   cr = SortedDict(Dict{Int,M1}())
   for (k,c) in coeffs(p)
     insert!(cr, k, map(x->convert(T1,x),c))
@@ -12,8 +12,8 @@ function _convert{T1,N,T2,M1,M2,W}(::Type{PolyMatrix{T1,M1,Val{W},N}},
   PolyMatrix(cr, size(p), Val{W})
 end
 
-@generated function convert{T1,N,T2,M1,M2,W}(::Type{PolyMatrix{T1,M1,Val{W},N}},
-  p::PolyMatrix{T2,M2,Val{W},N})
+@generated function convert(::Type{PolyMatrix{T1,M1,Val{W},N}},
+  p::PolyMatrix{T2,M2,Val{W},N}) where {T1,N,T2,M1,M2,W}
   if !(M1 <: AbstractArray{T1,N})
     return :(error("convert: first two parameters of first argument are incompatible"))
   elseif T1 == T2 && M1 == M2
@@ -24,8 +24,8 @@ end
 end
 
 # PolyMatrix and AbstractArray
-#promote_rule{T1,T2,M1,W,N}(::Type{PolyMatrix{T1,M1,Val{W},N}},
-#  ::Type{AbstractArray{T2,N}}) = PolyMatrix{promote_type(T1, T2), M1, Val{W}, N}
+#promote_rule(::Type{PolyMatrix{T1,M1,Val{W},N}},
+#  ::Type{AbstractArray{T2,N}}) where {T1,T2,M1,W,N} = PolyMatrix{promote_type(T1, T2), M1, Val{W}, N}
 
-#convert{T1,T2,M1,W,N}(::Type{PolyMatrix{T1,M1,Val{W},N}},
-#  p::AbstractArray{T2,N}) = PolyMatrix(p, size(p), Val{W})
+#convert(::Type{PolyMatrix{T1,M1,Val{W},N}},
+#  p::AbstractArray{T2,N}) where {T1,T2,M1,W,N} = PolyMatrix(p, size(p), Val{W})

--- a/src/filt.jl
+++ b/src/filt.jl
@@ -51,7 +51,7 @@ function filt!(out::AbstractArray{H}, b::PolyMatrix{T,M1,W,N},
 end
 
 function _filt_iir!(out::AbstractArray{T}, b::PolyMatrix{T,M1,W,N},
-  a::PolyMatrix{T,M2,W,N}, x::AbstractArray{S}, si::AbstractArray{G}) {T,S,M1,M2,W,N,G}
+  a::PolyMatrix{T,M2,W,N}, x::AbstractArray{S}, si::AbstractArray{G}) where {T,S,M1,M2,W,N,G}
   silen = size(si,2)
   bc = coeffs(b)
   ac = coeffs(a)

--- a/src/filt.jl
+++ b/src/filt.jl
@@ -1,15 +1,15 @@
-function _zerosi{S,G}(b::PolyMatrix{S}, a::PolyMatrix{G}, T)
+function _zerosi(b::PolyMatrix{S}, a::PolyMatrix{G}, T) where {S,G}
   m  = max(degree(a), degree(b))
   si = zeros(promote_type(S, G, T), size(a,1), m)
 end
 
-function filt{T,S,M1,M2,W,N,G}(b::PolyMatrix{T,M1,W,N}, a::PolyMatrix{S,M2,W,N},
-  x::AbstractArray{G}, si=_zerosi(b, a, G))
+function filt(b::PolyMatrix{T,M1,W,N}, a::PolyMatrix{S,M2,W,N},
+  x::AbstractArray{G}, si=_zerosi(b, a, G)) where {T,S,M1,M2,W,N,G}
   filt!(Array{promote_type(T, G, S)}(size(a,1), size(x,2)), b, a, x, si)
 end
 
-function filt!{H,T,S,M1,M2,W,N,G}(out::AbstractArray{H}, b::PolyMatrix{T,M1,W,N},
-  a::PolyMatrix{S,M2,W,N}, x::AbstractArray{G}, si=_zerosi(b, a, G))
+function filt!(out::AbstractArray{H}, b::PolyMatrix{T,M1,W,N},
+  a::PolyMatrix{S,M2,W,N}, x::AbstractArray{G}, si=_zerosi(b, a, G)) where {H,T,S,M1,M2,W,N,G}
 
   as = degree(a)
   bs = degree(b)
@@ -50,8 +50,8 @@ function filt!{H,T,S,M1,M2,W,N,G}(out::AbstractArray{H}, b::PolyMatrix{T,M1,W,N}
   return out
 end
 
-function _filt_iir!{T,S,M1,M2,W,N,G}(out::AbstractArray{T}, b::PolyMatrix{T,M1,W,N},
-  a::PolyMatrix{T,M2,W,N}, x::AbstractArray{S}, si::AbstractArray{G})
+function _filt_iir!(out::AbstractArray{T}, b::PolyMatrix{T,M1,W,N},
+  a::PolyMatrix{T,M2,W,N}, x::AbstractArray{S}, si::AbstractArray{G}) {T,S,M1,M2,W,N,G}
   silen = size(si,2)
   bc = coeffs(b)
   ac = coeffs(a)
@@ -80,8 +80,8 @@ function _filt_iir!{T,S,M1,M2,W,N,G}(out::AbstractArray{T}, b::PolyMatrix{T,M1,W
   truncate!(a)
 end
 
-function _filt_fir!{T,M1,W,N}(
-  out::AbstractMatrix{T}, b::PolyMatrix{T,M1,W,N}, x, si=zeros(T, size(b,1), degree(b)))
+function _filt_fir!(
+  out::AbstractMatrix{T}, b::PolyMatrix{T,M1,W,N}, x, si=zeros(T, size(b,1), degree(b))) where {T,M1,W,N}
   silen = size(si,2)
   bc = coeffs(b)
   v0 = zeros(similar(bc[first(keys(bc))]))
@@ -105,9 +105,9 @@ function _filt_fir!{T,M1,W,N}(
   truncate!(b)
 end
 
-function _filt_ar!{T,M1,W,N}(
+function _filt_ar!(
   out::AbstractMatrix{T}, a::PolyMatrix{T,M1,W,N},
-  x::AbstractArray{T}, si=zeros(T, size(a,1), degree(a)))
+  x::AbstractArray{T}, si=zeros(T, size(a,1), degree(a))) where {T,M1,W,N}
   silen = size(si,2)
   ac = coeffs(a)
   val = zeros(T, size(a,1), 1)

--- a/src/filt.jl
+++ b/src/filt.jl
@@ -26,7 +26,7 @@ function filt!(out::AbstractArray{H}, b::PolyMatrix{T,M1,W,N},
     throw(ArgumentError("First coefficient matrix must be nonzero of a"))
   end
   a0 = ac[0]
-  if a0 != eye(a0)
+  if a0 != Matrix{Float64}(I,size(a0))
     a = inv(a0)*a
     b = inv(a0)*b
   end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -337,7 +337,7 @@ end
 
 function isapprox(p₁::PolyMatrix{T1,M1,Val{W},N},
   n::AbstractArray{T2,N}; rtol::Real=Base.rtoldefault(T1,T2,0), atol::Real=0,
-  norm::Function=vecnorm) where {T1,M1,W,N,T2}
+  norm::Function=norm) where {T1,M1,W,N,T2}
   d = norm(p₁ - n)
   if isfinite(d)
     return d <= atol + rtol*max(norm(p₁), norm(n))

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -331,8 +331,8 @@ function isapprox(p₁::PolyMatrix{T1,M1,Val{W},N}, p₂::PolyMatrix{T2,M2,Val{W
 end
 function isapprox(p₁::PolyMatrix{T1,M1,Val{W1},N}, p₂::PolyMatrix{T2,M2,Val{W2},N};
   rtol::Real=Base.rtoldefault(T1,T2,0), atol::Real=0, norm::Function=norm) where {T1,M1,W1,W2,N,T2,M2}
-  @warn "p₁≈p₂: `p₁` ($T1,$W1) and `p₂` ($T2,$W2) have different variables"
-  throw(DomainError((p₁,p₂),"The two polynomial matrices have different variables."))
+  #@warn "p₁≈p₂: `p₁` ($T1,$W1) and `p₂` ($T2,$W2) have different variables"
+  throw(DomainError((p₁,p₂),"the two polynomial matrices have different variables."))
 end
 
 function isapprox(p₁::PolyMatrix{T1,M1,Val{W},N},

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -242,8 +242,7 @@ end
 # insert!
 function insert!(p::PolyMatrix{T,M,Val{W},N}, k::Int, A) where {T,M,W,N}
   if size(A) != size(p)
-    @warn "coefficient matrix to insert does not have the same size as polynomial matrix"
-    throw(DomainError())
+    throw(DomainError((p,k,A),"coefficient matrix to insert does not have the same size as polynomial matrix"))
   end
   insert!(coeffs(p), k, convert(M,A))
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1,30 +1,30 @@
 size(p::PolyMatrix) = p.dims
 size(p::PolyMatrix, i::Integer) = i ≤ length(p.dims) ? p.dims[i] : 1
 
-length{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})      = prod(size(p))
-start{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})       = 1
-next{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, state) = p[state], state+1
-done{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, state) = state > length(p)
-eltype{T,M,W,N}(::PolyMatrix{T,M,Val{W},N})       = Poly{T}
-vartype{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})     = W
-mattype{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})     = M
+length(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}     = prod(size(p))
+start(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}      = 1
+next(p::PolyMatrix{T,M,Val{W},N}, state) where {T,M,W,N}= p[state], state+1
+done(p::PolyMatrix{T,M,Val{W},N}, state) where {T,M,W,N}= state > length(p)
+eltype(::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}      = Poly{T}
+vartype(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}    = W
+mattype(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}    = M
 @compat Base.IndexStyle(::Type{<:PolyMatrix})     = IndexLinear()
 
-function similar{T,M,W,N,N2}(p::PolyMatrix{T,M,Val{W},N}, dims::NTuple{N2,Int})
+function similar(p::PolyMatrix{T,M,Val{W},N}, dims::NTuple{N2,Int}) where {T,M,W,N,N2}
   _,v1 = coeffs(p) |> first
   vr = zeros(similar(v1, T, dims))
   r = PolyMatrix(SortedDict(0=>vr), size(vr), Val{W})
 end
 
-function similar{T,M,W,N,S,N2}(p::PolyMatrix{T,M,Val{W},N}, ::Type{S}=T,
-  dims::NTuple{N2,Int}=size(p))
+function similar(p::PolyMatrix{T,M,Val{W},N}, ::Type{S}=T,
+  dims::NTuple{N2,Int}=size(p)) where {T,M,W,N,S,N2}
   _,v1 = coeffs(p) |> first
   vr = zeros(similar(v1, S, dims))
   r = PolyMatrix(SortedDict(0=>vr), size(vr), Val{W})
 end
 
-function similar{T,M,W,N,S,N2}(p::PolyMatrix{T,M,Val{W},N}, ::Type{Poly{S}},
-  dims::NTuple{N2,Int}=size(p))
+function similar(p::PolyMatrix{T,M,Val{W},N}, ::Type{Poly{S}},
+  dims::NTuple{N2,Int}=size(p)) where {T,M,W,N,S,N2}
   _,v1 = coeffs(p) |> first
   vr = zeros(similar(v1, S, dims))
   r = PolyMatrix(SortedDict(0=>vr), size(vr), Val{W})
@@ -34,32 +34,32 @@ function _matrixofpoly(p::PolyMatrix)
   [p[i,j] for i in 1:size(p,1), j in 1:size(p,2)]
 end
 
-function Base.vcat{T,M,W,N}(A::PolyMatrix{T,M,Val{W},N}...)
+function Base.vcat(A::PolyMatrix{T,M,Val{W},N}...) where {T,M,W,N}
   mvec  = map(_matrixofpoly, A)
   mpoly = vcat(mvec...)
   return PolyMatrix(mpoly, Val{W})
 end
 
-function Base.hcat{T,M,W,N}(A::PolyMatrix{T,M,Val{W},N}...)
+function Base.hcat(A::PolyMatrix{T,M,Val{W},N}...) where {T,M,W,N}
   mvec  = map(_matrixofpoly, A)
   mpoly = hcat(mvec...)
   return PolyMatrix(mpoly, Val{W})
 end
 
 # works but is not properly since @inferred do not give correct type
-function Base.cat{T,M,W,N}(catdims, A::PolyMatrix{T,M,Val{W},N}...)
+function Base.cat(catdims, A::PolyMatrix{T,M,Val{W},N}...) where {T,M,W,N}
   mvec  = map(_matrixofpoly, A)
   mpoly = cat(catdims, mvec...)
   return PolyMatrix(mpoly, Val{W})
 end
 
-function Base.hvcat{T,M,W,N}(nbc::Integer, A::PolyMatrix{T,M,Val{W},N}...)
+function Base.hvcat(nbc::Integer, A::PolyMatrix{T,M,Val{W},N}...) where {T,M,W,N}
   mvec  = map(_matrixofpoly, A)
   mpoly = hvcat(nbc, mvec...)
   return PolyMatrix(mpoly, Val{W})
 end
 
-function Base.hvcat{T,M,W,N,N2}(rows::NTuple{N2,Int}, A::PolyMatrix{T,M,Val{W},N}...)
+function Base.hvcat(rows::NTuple{N2,Int}, A::PolyMatrix{T,M,Val{W},N}...) where {T,M,W,N,N2}
   mvec  = map(_matrixofpoly, A)
   mpoly = hvcat(rows, mvec...)
   return PolyMatrix(mpoly, Val{W})
@@ -69,10 +69,10 @@ end
       variable(p::PolyMatrix)
   return variable of `p` as a `Poly` object.
 """
-variable{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}) = variable(T, @compat Symbol(W))
+variable(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N} = variable(T, @compat Symbol(W))
 
 # Copying
-function copy{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
+function copy(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
   cr  = SortedDict(Dict{Int,M}())
   for (k,v) in coeffs(p)
     insert!(cr, k, copy(v))
@@ -81,11 +81,11 @@ function copy{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
 end
 
 # getindex
-function Base.checkbounds{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, I...)
+function Base.checkbounds(p::PolyMatrix{T,M,Val{W},N}, I...) where {T,M,W,N}
   checkbounds(first(coeffs(p))[2], I...)
 end
 
-function getindex{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, i::Integer)
+function getindex(p::PolyMatrix{T,M,Val{W},N}, i::Integer) where {T,M,W,N}
   @compat @boundscheck checkbounds(p, i)
   vr = zeros(T, degree(p)+1)
   for (k,v) in coeffs(p)
@@ -94,7 +94,7 @@ function getindex{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, i::Integer)
   r = Poly(vr, W)
 end
 
-function getindex{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, i::Integer, j::Integer)
+function getindex(p::PolyMatrix{T,M,Val{W},N}, i::Integer, j::Integer) where {T,M,W,N}
   vr = zeros(T, degree(p)+1)
   for (k,v) in coeffs(p)
     vr[k+1] = v[i,j]
@@ -102,7 +102,7 @@ function getindex{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, i::Integer, j::Integer)
   r = Poly(vr, W)
 end
 
-function getindex{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, I...)
+function getindex(p::PolyMatrix{T,M,Val{W},N}, I...) where {T,M,W,N}
   c   = coeffs(p)
   _,v = first(c)
   vr  = getindex(v, I...)
@@ -114,7 +114,7 @@ function getindex{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, I...)
 end
 
 # setindex!
-function setindex!{T,M,W,N,U}(Pm::PolyMatrix{T,M,Val{W},N}, p::Poly{U}, i::Integer)
+function setindex!(Pm::PolyMatrix{T,M,Val{W},N}, p::Poly{U}, i::Integer) where {T,M,W,N,U}
   @compat @boundscheck checkbounds(Pm, i)
   c = coeffs(p)
   Pmc = coeffs(Pm)
@@ -139,8 +139,8 @@ function setindex!{T,M,W,N,U}(Pm::PolyMatrix{T,M,Val{W},N}, p::Poly{U}, i::Integ
   end
 end
 
-function setindex!{T,M,W,U}(Pm::PolyMatrix{T,M,Val{W},2}, p::Poly{U},
-    i::Integer, j::Integer)
+function setindex!(Pm::PolyMatrix{T,M,Val{W},2}, p::Poly{U},
+    i::Integer, j::Integer) where {T,M,W,U}
   @compat @boundscheck checkbounds(Pm, i, j)
   c = coeffs(p)
   Pmc = coeffs(Pm)
@@ -165,8 +165,8 @@ function setindex!{T,M,W,U}(Pm::PolyMatrix{T,M,Val{W},2}, p::Poly{U},
   end
 end
 
-function setindex!{T,M,W,N,U}(Pm::PolyMatrix{T,M,Val{W},N}, p::Poly{U},
-    I...)
+function setindex!(Pm::PolyMatrix{T,M,Val{W},N}, p::Poly{U},
+    I...) where {T,M,W,N,U}
   @compat @boundscheck checkbounds(Pm, I...)
   c = coeffs(p)
   Pmc = coeffs(Pm)
@@ -192,7 +192,7 @@ function setindex!{T,M,W,N,U}(Pm::PolyMatrix{T,M,Val{W},N}, p::Poly{U},
 end
 
 # setindex for number
-function setindex!{T,M,W,N,T2<:Number}(Pm::PolyMatrix{T,M,Val{W},N}, p::T2, i::Integer)
+function setindex!(Pm::PolyMatrix{T,M,Val{W},N}, p::T2, i::Integer) where {T,M,W,N,T2<:Number}
   @compat @boundscheck checkbounds(Pm, i)
   c = coeffs(Pm)
   hasconst = false
@@ -207,8 +207,8 @@ function setindex!{T,M,W,N,T2<:Number}(Pm::PolyMatrix{T,M,Val{W},N}, p::T2, i::I
   end
 end
 
-function setindex!{T,M,W,T2<:Number}(Pm::PolyMatrix{T,M,Val{W},2}, p::T2,
-    i::Integer, j::Integer)
+function setindex!(Pm::PolyMatrix{T,M,Val{W},2}, p::T2,
+    i::Integer, j::Integer) where {T,M,W,T2<:Number}
   @compat @boundscheck checkbounds(Pm, i, j)
   c = coeffs(Pm)
   hasconst = false
@@ -223,8 +223,8 @@ function setindex!{T,M,W,T2<:Number}(Pm::PolyMatrix{T,M,Val{W},2}, p::T2,
   end
 end
 
-function setindex!{T,M,W,N,T2<:Number}(Pm::PolyMatrix{T,M,Val{W},N}, p::T2,
-    I...)
+function setindex!(Pm::PolyMatrix{T,M,Val{W},N}, p::T2,
+    I...) where {T,M,W,N,T2<:Number}
   @compat @boundscheck checkbounds(Pm, I...)
   c = coeffs(Pm)
   hasconst = false
@@ -240,7 +240,7 @@ function setindex!{T,M,W,N,T2<:Number}(Pm::PolyMatrix{T,M,Val{W},N}, p::T2,
 end
 
 # insert!
-function insert!{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}, k::Int, A)
+function insert!(p::PolyMatrix{T,M,Val{W},N}, k::Int, A) where {T,M,W,N}
   if size(A) != size(p)
     warn("coefficient matrix to insert does not have the same size as polynomial matrix")
     throw(DomainError())
@@ -252,9 +252,9 @@ end
 coeffs(p::PolyMatrix) = p.coeffs
 
 ## Maximum degree of the polynomials in a polynomial matrix
-degree{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})  = last(coeffs(p))[1]
+degree(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}  = last(coeffs(p))[1]
 
-function transpose{T,M<:AbstractMatrix,W,N}(p::PolyMatrix{T,M,Val{W},N})
+function transpose(p::PolyMatrix{T,M,Val{W},N}) where {T,M<:AbstractMatrix,W,N}
   cr = SortedDict(Dict{Int,M}())
   for (k,v) in p.coeffs
     insert!(cr, k, transpose(v))
@@ -262,7 +262,7 @@ function transpose{T,M<:AbstractMatrix,W,N}(p::PolyMatrix{T,M,Val{W},N})
   PolyMatrix(cr, reverse(p.dims), Val{W})
 end
 
-function ctranspose{T1,M1,W,N}(p::PolyMatrix{T1,M1,Val{W},N})
+function ctranspose(p::PolyMatrix{T1,M1,Val{W},N}) where {T1,M1,W,N}
   c     = coeffs(p)
   k1,v1 = first(c)
   vr    = ctranspose(v1)
@@ -278,16 +278,16 @@ end
 # TODO Lₚ norms
 # vecnorm
 # stacks all coefficient matrices and calls built in vecnorm on resulting tall matrix
-function vecnorm{T1,M1,W,N}(p₁::PolyMatrix{T1,M1,Val{W},N}, p::Real=2)
+function vecnorm(p₁::PolyMatrix{T1,M1,Val{W},N}, p::Real=2) where {T1,M1,W,N}
   c = coeffs(p₁)
   vecnorm(vcat(values(c)...), p)
 end
 
 ## Comparison
-=={T1,M1,W,N,T2,M2}(p₁::PolyMatrix{T1,M1,Val{W},N}, p₂::PolyMatrix{T2,M2,Val{W},N}) = (p₁.coeffs == p₂.coeffs)
-=={T1,M1,W1,W2,N,T2,M2}(p₁::PolyMatrix{T1,M1,Val{W1},N}, p₂::PolyMatrix{T2,M2,Val{W2},N}) = false
+==(p₁::PolyMatrix{T1,M1,Val{W},N}, p₂::PolyMatrix{T2,M2,Val{W},N}) where {T1,M1,W,N,T2,M2} = (p₁.coeffs == p₂.coeffs)
+==(p₁::PolyMatrix{T1,M1,Val{W1},N}, p₂::PolyMatrix{T2,M2,Val{W2},N}) where {T1,M1,W1,W2,N,T2,M2} = false
 
-function =={T1,M1,W,N,M2<:AbstractArray}(p₁::PolyMatrix{T1,M1,Val{W},N}, n::M2)
+function ==(p₁::PolyMatrix{T1,M1,Val{W},N}, n::M2) where {T1,M1,W,N,M2<:AbstractArray}
   c = coeffs(p₁)
   has_zero = false
   for (k,v) in c
@@ -300,14 +300,14 @@ function =={T1,M1,W,N,M2<:AbstractArray}(p₁::PolyMatrix{T1,M1,Val{W},N}, n::M2
   end
   return ifelse(has_zero, true, n == zeros(n))
 end
-=={T1,M1,W,N,M2<:AbstractArray}(n::M2, p₁::PolyMatrix{T1,M1,Val{W},N}) = (p₁ == n)
+==(n::M2, p₁::PolyMatrix{T1,M1,Val{W},N}) where {T1,M1,W,N,M2<:AbstractArray} = (p₁ == n)
 
-hash{T1,M1,W,N}(p::PolyMatrix{T1,M1,Val{W},N}, h::UInt) = hash(W, hash(coeffs(p), h))
+hash(p::PolyMatrix{T1,M1,Val{W},N}, h::UInt) where {T1,M1,W,N} = hash(W, hash(coeffs(p), h))
 isequal(p₁::PolyMatrix, p₂::PolyMatrix) = hash(p₁) == hash(p₂)
 
-function isapprox{T1,M1,W,N,T2,M2}(p₁::PolyMatrix{T1,M1,Val{W},N}, p₂::PolyMatrix{T2,M2,Val{W},N};
+function isapprox(p₁::PolyMatrix{T1,M1,Val{W},N}, p₂::PolyMatrix{T2,M2,Val{W},N};
   rtol::Real=length(p₁)*degree(p₁)*degree(p₂)*Base.rtoldefault(T1,T2),
-  atol::Real=0, norm::Function=vecnorm)
+  atol::Real=0, norm::Function=vecnorm) where {T1,M1,W,N,T2,M2}
   d = norm(p₁ - p₂)
   if isfinite(d)
     return d <= atol + rtol*max(norm(p₁), norm(p₂))
@@ -329,15 +329,15 @@ function isapprox{T1,M1,W,N,T2,M2}(p₁::PolyMatrix{T1,M1,Val{W},N}, p₂::PolyM
     return true
   end
 end
-function isapprox{T1,M1,W1,W2,N,T2,M2}(p₁::PolyMatrix{T1,M1,Val{W1},N}, p₂::PolyMatrix{T2,M2,Val{W2},N};
-  rtol::Real=Base.rtoldefault(T1,T2), atol::Real=0, norm::Function=vecnorm)
+function isapprox(p₁::PolyMatrix{T1,M1,Val{W1},N}, p₂::PolyMatrix{T2,M2,Val{W2},N};
+  rtol::Real=Base.rtoldefault(T1,T2), atol::Real=0, norm::Function=vecnorm) where {T1,M1,W1,W2,N,T2,M2}
   warn("p₁≈p₂: `p₁` ($T1,$W1) and `p₂` ($T2,$W2) have different variables")
   throw(DomainError())
 end
 
-function isapprox{T1,M1,W,N,T2}(p₁::PolyMatrix{T1,M1,Val{W},N},
+function isapprox(p₁::PolyMatrix{T1,M1,Val{W},N},
   n::AbstractArray{T2,N}; rtol::Real=Base.rtoldefault(T1,T2), atol::Real=0,
-  norm::Function=vecnorm)
+  norm::Function=vecnorm) where {T1,M1,W,N,T2}
   d = norm(p₁ - n)
   if isfinite(d)
     return d <= atol + rtol*max(norm(p₁), norm(n))
@@ -355,22 +355,22 @@ function isapprox{T1,M1,W,N,T2}(p₁::PolyMatrix{T1,M1,Val{W},N},
     return ifelse(has_zero, true, isapprox(n,zeros(n); rtol=rtol, atol=atol, norm=norm))
   end
 end
-isapprox{T1,M1,W,N,T2}(n::AbstractArray{T2,N}, p₁::PolyMatrix{T1,M1,Val{W},N}) = (p₁ ≈ n)
+isapprox(n::AbstractArray{T2,N}, p₁::PolyMatrix{T1,M1,Val{W},N}) where {T1,M1,W,N,T2} = (p₁ ≈ n)
 
-function isapprox{T1,M1,W,N,T2}(p₁::PolyMatrix{T1,M1,Val{W},N},
+function isapprox(p₁::PolyMatrix{T1,M1,Val{W},N},
   n::AbstractArray{Poly{T2},N}; rtol::Real=Base.rtoldefault(T1,T2),
-  atol::Real=0, norm::Function=vecnorm)
+  atol::Real=0, norm::Function=vecnorm) where {T1,M1,W,N,T2}
   return isapprox(p₁, PolyMatrix(n); rtol=rtol, atol=atol, norm=norm)
 end
 
-function isapprox{T1,M1,W,N,T2}(n::AbstractArray{Poly{T2},N},
+function isapprox(n::AbstractArray{Poly{T2},N},
   p₁::PolyMatrix{T1,M1,Val{W},N}; rtol::Real=Base.rtoldefault(T1,T2),
-  atol::Real=0, norm::Function=vecnorm)
+  atol::Real=0, norm::Function=vecnorm) where {T1,M1,W,N,T2}
   return isapprox(PolyMatrix(n), p₁; rtol=rtol, atol=atol, norm=norm)
 end
 
 
-function rank{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
+function rank(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
   d = degree(p)+1
   # copy all elements into three-dimensional matrix
   A = zeros(size(p)...,d)
@@ -382,7 +382,7 @@ function rank{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N})
   return maximum(a)
 end
 
-fastrank{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}) = rank(p(randn(1)...))
+fastrank(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N} = rank(p(randn(1)...))
 
-summary{T,M,W,N}(p::PolyMatrix{T,M,Val{W},N}) =
+summary(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N} =
   string(Base.dims2string(p.dims), " PolyArray{$T,$N}")

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -2,9 +2,9 @@ size(p::PolyMatrix) = p.dims
 size(p::PolyMatrix, i::Integer) = i ≤ length(p.dims) ? p.dims[i] : 1
 
 length(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}     = prod(size(p))
-start(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}      = 1
-next(p::PolyMatrix{T,M,Val{W},N}, state) where {T,M,W,N}= p[state], state+1
-done(p::PolyMatrix{T,M,Val{W},N}, state) where {T,M,W,N}= state > length(p)
+# start(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}      = 1 # no longer needed in Julia 1.x but temporarily left here for possible consulting if things brake. The same below.
+# next(p::PolyMatrix{T,M,Val{W},N}, state) where {T,M,W,N}= p[state], state+1
+# done(p::PolyMatrix{T,M,Val{W},N}, state) where {T,M,W,N}= state > length(p)
 eltype(::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}      = Poly{T}
 vartype(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}    = W
 mattype(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}    = M

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -32,7 +32,7 @@ function gcrd(p₁::PolyMatrix{T1,M1,Val{W},N},
   p₂::PolyMatrix{T2,M2,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M1,W,N,T2,M2}
   n₁,m₁ = size(p₁)
   n₂,m₂ = size(p₂)
-  m₁ == m₂ || (@warn "gcrd: p₁ and p₂ does note have the same number of columns"; throw(DomainError()))
+  m₁ == m₂ || throw(DimensionMismatch("the two polynomial matrices do not have the same number of columns"))
   R,U   = rtriang([p₁; p₂], iterative, dᵤ)
   detU, adjU = inv(U)
   V     = adjU/detU(0)
@@ -75,7 +75,7 @@ function gcld(p₁::PolyMatrix{T1,M1,Val{W},N},
   p₂::PolyMatrix{T2,M2,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M1,W,N,T2,M2}
   n₁,m₁ = size(p₁)
   n₂,m₂ = size(p₂)
-  n₁ == n₂ || (@warn "gcrd: p₁ and p₂ does note have the same number of columns"; throw(DomainError()))
+  n₁ == n₂ || throw(DimensionMismatch("the two polynomial matrices do not have the same number of columns"))
   L,U   = ltriang([p₁ p₂], iterative, dᵤ)
   detU, adjU = inv(U)
   V     = adjU/detU(0)

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -244,7 +244,7 @@ function _ltriang(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=
   Rd = zeros(T, n*(d+1), mₛ)
   for (k,v) in coeffs(p)
     for i in 0:n-1, j in 0:dᵤ
-      Rd[n*(d+1)-i*(d+1)-k-dᵤ+j, j*m+(1:m)] = v[n-i,:]
+      Rd[n*(d+1)-i*(d+1)-k-dᵤ+j, j*m .+ (1:m)] = v[n-i,:]
     end
   end
   # should be changed when support for 0.4 drops (lq not in 0.4)

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -75,7 +75,7 @@ function gcld(p₁::PolyMatrix{T1,M1,Val{W},N},
   p₂::PolyMatrix{T2,M2,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M1,W,N,T2,M2}
   n₁,m₁ = size(p₁)
   n₂,m₂ = size(p₂)
-  n₁ == n₂ || (@warn"gcrd: p₁ and p₂ does note have the same number of columns"; throw(DomainError()))
+  n₁ == n₂ || (@warn "gcrd: p₁ and p₂ does note have the same number of columns"; throw(DomainError()))
   L,U   = ltriang([p₁ p₂], iterative, dᵤ)
   detU, adjU = inv(U)
   V     = adjU/detU(0)

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -266,8 +266,8 @@ function _ltriang(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=
     # sort in decreasing order
     v = sortperm(Σb)
     U2 = zeros(T, mₛ, mₛ)
-    for j in 1:mₛ
-      U2[j,v[j]] = one(T)
+    for k in 1:mₛ
+      U2[k,v[k]] = one(T)
     end
     L = L*transpose(U2)
     U = U2*U

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -171,7 +171,7 @@ julia> L
 function ltriang(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M,W,N}
   n,m = size(p)
   if n < m || rank(p) < m
-    pₑ = vcat(p, PolyMatrix(Matrix{Float64}(m,m), (m,m), Val{W}))
+    pₑ = vcat(p, PolyMatrix(Matrix{Float64}(undef,m,m), (m,m), Val{W}))
   else
     pₑ = p
   end
@@ -217,7 +217,7 @@ end
 function _unshift(L::AbstractMatrix,d::Int)
   n,r = divrem(size(L,1), d+1)
   r == 0 || throw(DimensionMismatch())
-  SL = zeros(L)
+  SL = zero(L)
   for i in 0:d
     for j in 0:n-1
       SL[(d-i)*n+j+1,:] = L[(j)*(d+1)+d-i+1,:]

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -300,7 +300,7 @@ function _ltriang(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=
   # The following line is suggested by testing and not by the paper ?!
   # It handles cases where the first rows in the
   # triangular form are zero
-  Σb = Σb - Σb[1]+1
+  Σb = Σb .- Σb[1] .+ 1
 
   Σ = zeros(Int,0)
   for i in 1:m*(dᵤ+1)

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -117,7 +117,7 @@ function hermite(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=-
   n,m   = size(p)
 
   # scale diagonal elements first
-  Σ = [findfirst(L[:,k]) for k in 1:m]
+  Σ = [findfirst(x -> x!=0, L[:,k]) for k in 1:m]
   U1 = Diagonal([1 ./ L[Σ[k],k] for k in 1:m])
   U = U*U1
   L = L*U1

--- a/src/reductions.jl
+++ b/src/reductions.jl
@@ -32,7 +32,7 @@ function gcrd(p₁::PolyMatrix{T1,M1,Val{W},N},
   p₂::PolyMatrix{T2,M2,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M1,W,N,T2,M2}
   n₁,m₁ = size(p₁)
   n₂,m₂ = size(p₂)
-  m₁ == m₂ || (warn("gcrd: p₁ and p₂ does note have the same number of columns"); throw(DomainError()))
+  m₁ == m₂ || (@warn "gcrd: p₁ and p₂ does note have the same number of columns"; throw(DomainError()))
   R,U   = rtriang([p₁; p₂], iterative, dᵤ)
   detU, adjU = inv(U)
   V     = adjU/detU(0)
@@ -75,7 +75,7 @@ function gcld(p₁::PolyMatrix{T1,M1,Val{W},N},
   p₂::PolyMatrix{T2,M2,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M1,W,N,T2,M2}
   n₁,m₁ = size(p₁)
   n₂,m₂ = size(p₂)
-  n₁ == n₂ || (warn("gcrd: p₁ and p₂ does note have the same number of columns"); throw(DomainError()))
+  n₁ == n₂ || (@warn"gcrd: p₁ and p₂ does note have the same number of columns"; throw(DomainError()))
   L,U   = ltriang([p₁ p₂], iterative, dᵤ)
   detU, adjU = inv(U)
   V     = adjU/detU(0)
@@ -123,7 +123,7 @@ function hermite(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=-
   L = L*U1
 
   # reduce order
-  U2 = eye(m)
+  U2 = Matrix{Float64}(I,m,m)
   for i in 2:m
     for j in 1:i-1
       σ = Σ[i]
@@ -171,7 +171,7 @@ julia> L
 function ltriang(p::PolyMatrix{T1,M,Val{W},N}, iterative::Bool=true, dᵤ::Int=-1) where {T1,M,W,N}
   n,m = size(p)
   if n < m || rank(p) < m
-    pₑ = vcat(p, PolyMatrix(eye(T1,m), size(eye(m)), Val{W}))
+    pₑ = vcat(p, PolyMatrix(Matrix{Float64}(m,m), (m,m), Val{W}))
   else
     pₑ = p
   end
@@ -453,7 +453,7 @@ function colred(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
   p_temp = copy(p)
   c       = coeffs(p_temp)         # Dictionary of coefficient matrices of p
   num_col = N < 2 ? 1 : size(p,2)  # Number of columns of p
-  U       = PolyMatrix(eye(T,num_col), Val{W})
+  U       = PolyMatrix(Matrix{Float64}(num_col,num_col), Val{W})
 
   indN    = zeros(Int,num_col)  # Collection of non-zero entries of n
   while true
@@ -487,7 +487,7 @@ function colred(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
     end
 
     # Unimodular matrix Utemp
-    Utemp = SortedDict(0 => eye(T,num_col))
+    Utemp = SortedDict(0 => Matrix{Float64}(num_col,num_col))
     for i = 1:max_temp-minimum(k[indN[1:num_nz]])
       insert!(Utemp, i, zeros(T,num_col,num_col))
     end
@@ -605,7 +605,7 @@ function rowred(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
   p_temp  = copy(p)
   c       = coeffs(p_temp)  # Dictionary of coefficient matrices of p
   num_row = size(p,1)      # Number of rows of p
-  U       = PolyMatrix(eye(T,num_row), Val{W})
+  U       = PolyMatrix(Matrix{Float64}(num_row,num_row), Val{W})
 
   indN    = zeros(Int,num_row)  # Collection of non-zero entries of n
   while true
@@ -640,7 +640,7 @@ function rowred(p::PolyMatrix{T,M,Val{W},N}) where {T,M,W,N}
     end
 
     # Unimodular matrix Utemp
-    Utemp = SortedDict(0 => eye(T,num_row))
+    Utemp = SortedDict(0 => Matrix{Float64}(num_row,num_row))
     #insert!(Utemp, 0, )
     for i = 1:max_temp-minimum(k[indN[1:num_nz]])
       insert!(Utemp, i, zeros(T,num_row,num_row))

--- a/src/type.jl
+++ b/src/type.jl
@@ -155,7 +155,7 @@ function PolyMatrix(A::M, dims::Tuple{Int,Int}, ::Type{Val{W}}; reverse::Bool=fa
   p0 = dn > 0 ? A[1:ny, :] : zeros(eltype(A),dims)
   c  = SortedDict(Dict{Int,typeof(p0)}())
   for k = 0:dn-1
-    idx = reverse ? (dn-k-1)*ny+(1:ny) : k*ny+(1:ny)
+    idx = reverse ? (dn-k-1)*ny .+ (1:ny) : k*ny .+ (1:ny)
     v = A[idx, :]
     insert!(c, k, v)
   end

--- a/src/type.jl
+++ b/src/type.jl
@@ -67,15 +67,13 @@ end
 
 function PolyMatrix(d::Dict{Int,M}, var::Type{Val{W}}) where {M<:AbstractArray,W}
   if length(d) ≤ 0
-    @warn "PolyMatrix: length(d) == 0"
-    throw(DomainError())
+    throw(DomainError(d,"PolyMatrix: length(d) == 0"))
   end
   c = SortedDict(d)
   n,m = size(first(c)[2])
   for (k,v) in c
     if size(v) != (n,m)
-      @warn "PolyMatrix: size of elements not consistent"
-      throw(DomainError())
+      throw(DomainError(d,"PolyMatrix: size of elements not consistent"))
     end
   end
   PolyMatrix(c, (n,m), Val{W})

--- a/src/type.jl
+++ b/src/type.jl
@@ -1,3 +1,4 @@
+
 # Parameters:
 #   T: type of the polynomials' coefficients
 #   M: type of the matrices of coefficients
@@ -38,7 +39,7 @@ function _truncate!(coeffs::SortedDict{Int,M,ForwardOrdering},
     end
   end
   if length(coeffs) == zero(T)
-    insert!(coeffs, 0, zeros(v1))
+    insert!(coeffs, 0, zero(v1))
   end
   coeffs
 end
@@ -66,14 +67,14 @@ end
 
 function PolyMatrix(d::Dict{Int,M}, var::Type{Val{W}}) where {M<:AbstractArray,W}
   if length(d) ≤ 0
-    warn("PolyMatrix: length(d) == 0")
+    @warn "PolyMatrix: length(d) == 0"
     throw(DomainError())
   end
   c = SortedDict(d)
   n,m = size(first(c)[2])
   for (k,v) in c
     if size(v) != (n,m)
-      warn("PolyMatrix: size of elements not consistent")
+      @warn "PolyMatrix: size of elements not consistent"
       throw(DomainError())
     end
   end
@@ -81,7 +82,7 @@ function PolyMatrix(d::Dict{Int,M}, var::Type{Val{W}}) where {M<:AbstractArray,W
 end
 
 function PolyMatrix(PM::M1) where M1<:AbstractArray
-  var = countnz(PM) > 0 ? PM[findfirst(x -> x != zero(x), PM)].var :
+  var = count(!iszero,PM) > 0 ? PM[findfirst(x -> x != zero(x), PM)].var :
                          Poly(T[]).var       # default to Polys default variable
   PolyMatrix(PM, Val{@compat Symbol(var)})
 end
@@ -130,7 +131,7 @@ function PolyMatrix(A::M, dims::Tuple{Int}, ::Type{Val{W}}) where {M<:AbstractAr
   ny = dims[1]
   dn = div(size(A,1), ny)
   if rem(size(A,1), ny) != 0
-    warn("PolyMatrix: dimensions are not consistent")
+    @warn "PolyMatrix: dimensions are not consistent"
     throw(DomainError())
   end
   p0 = dn > 0 ? p0 = A[1:ny] : zeros(eltype(A), dims)
@@ -151,7 +152,7 @@ function PolyMatrix(A::M, dims::Tuple{Int,Int}, ::Type{Val{W}}; reverse::Bool=fa
   ny = dims[1]
   dn = div(size(A,1), ny)
   if rem(size(A,1), ny) != 0 || size(A,2) != dims[2]
-    warn("PolyMatrix: dimensions are not consistent")
+    @warn "PolyMatrix: dimensions are not consistent"
     throw(DomainError())
   end
   p0 = dn > 0 ? A[1:ny, :] : zeros(eltype(A),dims)
@@ -170,7 +171,7 @@ end
 
 function PolyMatrix(A::M, dims::Tuple{Int,Int,Int}, ::Type{Val{W}}) where {M<:AbstractArray,W}
   if size(A) != dims && dims[3] < 1
-    warn("PolyMatrix: dimensions are not consistent")
+    @warn "PolyMatrix: dimensions are not consistent"
     throw(DomainError())
   end
   dn = dims[3]
@@ -181,5 +182,5 @@ function PolyMatrix(A::M, dims::Tuple{Int,Int,Int}, ::Type{Val{W}}) where {M<:Ab
     p = A[:, :, k+1]
     if (sum(abs2,p) > zero(eltype(A))) insert!(c, k, p) end
   end
-  return PolyMatrix(c, size(A,1,2), Val{W})
+  return PolyMatrix(c, (size(A,1),size(A,2)), Val{W})
 end

--- a/src/type.jl
+++ b/src/type.jl
@@ -150,8 +150,7 @@ function PolyMatrix(A::M, dims::Tuple{Int,Int}, ::Type{Val{W}}; reverse::Bool=fa
   ny = dims[1]
   dn = div(size(A,1), ny)
   if rem(size(A,1), ny) != 0 || size(A,2) != dims[2]
-    @warn "PolyMatrix: dimensions are not consistent"
-    throw(DomainError())
+    throw(DomainError((A,dims),"PolyMatrix: dimensions are not consistent"))
   end
   p0 = dn > 0 ? A[1:ny, :] : zeros(eltype(A),dims)
   c  = SortedDict(Dict{Int,typeof(p0)}())

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -4,19 +4,19 @@ p2  = Poly([2,1,3,4],:s)
 p3  = Poly([2,3,4,5,7],:s)
 m   = [p1 p2; p3 p1]
 pm1 = PolyMatrix(m)
-pm2 = PolyMatrix(m+1.0)
+pm2 = PolyMatrix(m .+ 1.0)
 pm3 = PolyMatrix(hcat(m,m))
-pm4 = PolyMatrix(eye(2),:x)
+pm4 = PolyMatrix(Matrix{Float64}(I,2,2),:x)
 n1  = 1
 n2  = 0.0
-a1  = eye(2,2)
-a2  = eye(2,4)
+a1  = Matrix{Float64}(I,2,2)
+a2  = Matrix{Float64}(I,2,4)
 v1  = ones(2)
 v2  = ones(4)
 
 # addition
 @test pm1+pm1 == PolyMatrix(2*m)
-@test pm1+pm2 == PolyMatrix(2*m+1)
+@test pm1+pm2 == PolyMatrix(2*m .+ 1)
 @test_throws DomainError pm1+pm3
 @test_throws DomainError pm1+pm4
 #@inferred pm1+pm1

--- a/test/filt.jl
+++ b/test/filt.jl
@@ -4,10 +4,10 @@ p1  = Poly([2,1,3.], :s)
 p2  = Poly([2,1,3.1], :s)
 pm1 = PolyMatrix([p1 p2; p2 p1])
 pm2 = PolyMatrix([p1 p2; p2 p2])
-pm3 = PolyMatrix(eye(2,2), :s)
+pm3 = PolyMatrix(Matrix{Float64}(I,2,2), :s)
 
 A0 = [2.0 1.0; 0.5 3.0]
-coeffs(pm1)[0] = eye(2)   #
+coeffs(pm1)[0] = Matrix{Float64}(I,2,2)   #
 coeffs(pm2)[0] = A0       # set first coefficient matrix to an invertible matrix
 
 N = 100

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -14,8 +14,8 @@ pm2 = PolyMatrix(m2)
 pm3 = PolyMatrix(m3)
 pm4 = PolyMatrix(m4)
 pm5 = PolyMatrix(m5)
-pm6 = PolyMatrix(eye(2), :s)
-pm7 = PolyMatrix(eye(2), :z)
+pm6 = PolyMatrix(Matrix{Float64}(I,2,2), :s)
+pm7 = PolyMatrix(Matrix{Float64}(I,2,2), :z)
 
 @test pm1 != pm2 != pm3 != pm4 != pm5
 @test pm6 != pm7
@@ -24,7 +24,7 @@ pm7 = PolyMatrix(eye(2), :z)
 @test !isapprox(pm3,pm4; rtol=0.01)
 @test isapprox(pm3,pm4; rtol=0.1)
 @test !isapprox(pm3,pm4; rtol=0.001)
-@test isapprox(eye(2),pm6)
+@test isapprox(Matrix{Float64}(I,2,2),pm6)
 @test !isapprox(pm1,pm3)
 
 @test !isapprox(pm3,m4; rtol=0.01)
@@ -107,11 +107,11 @@ hvcat(1, pm1, pm1)
 @test [pm1 pm2; pm2 pm1] == PolyMatrix([m1 m2; m2 m1])
 #@inferred hvcat((2,2), pm1,pm2,pm2,pm1)
 
-#@test vcat(pm1, eye(Int, 2)) == PolyMatrix(vcat(m1, eye(Int, 2)))
-#@inferred vcat(pm1, eye(Int, 2))
+#@test vcat(pm1, Matrix{Int}(I,2,2)) == PolyMatrix(vcat(m1, Matrix{Int}(I,2,2)))
+#@inferred vcat(pm1, Matrix{Int}(I,2,2))
 
-#@test hcat(pm1, eye(2)) == PolyMatrix(hcat(m1, eye(2)))
-#@inferred vcat(pm1, eye(2))
+#@test hcat(pm1, Matrix{Float64}(I,2,2)) == PolyMatrix(hcat(m1, Matrix{Float64}(I,2,2)))
+#@inferred vcat(pm1, Matrix{Float64}(I,2,2))
 
 # test getindex
 p1  = Poly([1],:s)
@@ -123,7 +123,7 @@ degreepm2 = 8
 ny  = 2
 nu  = 2
 A   = randn(ny*(degreepm2+1),nu)
-B   = eye(Float64,2)
+B   = Matrix{Float64}(I,2,2)
 pm1[1].a
 pm2 = PolyMatrix(A, (ny,nu))
 pm3 = PolyMatrix(B)
@@ -192,7 +192,7 @@ for elem in pm2
 end
 
 for idx in eachindex(pm3)
-  @test degree(pm3[idx]) == 0
+  @test degree(pm3[idx]) <= 0   # Polynomial.jl shifted from degree(p-p)=0 to degree(p-p)=-1
 end
 
 @test coeffs(pm3[end]) ≈ coeffs(one(Poly{Float64}))

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -198,7 +198,7 @@ end
 @test coeffs(pm3[end]) ≈ coeffs(one(Poly{Float64}))
 #@inferred coeffs(pm3[end])
 
-# test transpose and ctranspose
+# test transpose and adjoint
 pm4[2] = p3
 pm5 = transpose(pm4)
 @test coeffs(pm4[2]) ≈ coeffs(pm5[3])
@@ -206,8 +206,8 @@ pm5 = transpose(pm4)
 
 C   = randn(2,2) + randn(2,2)im
 pm6 = PolyMatrix(C)
-@test coeffs(ctranspose(pm6))[0] ≈ ctranspose(C)
-#@inferred ctranspose(pm4)
+@test coeffs(adjoint(pm6))[0] ≈ adjoint(C)
+#@inferred adjoint(pm4)
 
 # test rank
 p1  = Poly([1],:s)

--- a/test/reductions.jl
+++ b/test/reductions.jl
@@ -7,18 +7,18 @@ L₀ = PolyMatrix([-1.225s+1.225 zero(s); -2.450*one(s) zero(s); -1.225*one(s) 1
 @test isapprox(L, L₀; rtol=1e-3)
 @test isapprox(p*U, L)
 
-R,U = rtriang(p.', false, 1)
-@test isapprox(R.', L₀; rtol=1e-3)
-@test isapprox(U*p.', R)
+R,U = rtriang(copy(transpose(p)), false, 1)
+@test isapprox(copy(transpose(R)), L₀; rtol=1e-3)
+@test isapprox(U*transpose(p), R)
 
 L,U = ltriang(p)
 @test isapprox(p*U, L₀; rtol=1e-3)
 @test isapprox(L, L₀; rtol=1e-3)
 @test isapprox(p*U, L)
 
-R,U = rtriang(p.')
-@test isapprox(R.', L₀; rtol=1e-3)
-@test isapprox(U*p.', R)
+R,U = rtriang(copy(transpose(p)))
+@test isapprox(copy(transpose(R)), L₀; rtol=1e-3)
+@test isapprox(U*transpose(p), R)
 
 # hermite
 s = variable("s")
@@ -44,10 +44,10 @@ R, V₁, V₂ = gcrd(p₁, p₂)
 @test V₁*R ≈ p₁
 @test V₂*R ≈ p₂
 
-L, V₁, V₂ = gcld(p₁.', p₂.')
-@test hermite(L)[1] ≈ hermite(R₀.')[1]
-@test L*V₁ ≈ p₁.'
-@test L*V₂ ≈ p₂.'
+L, V₁, V₂ = gcld(copy(transpose(p₁)),copy(transpose(p₂)))
+@test hermite(L)[1] ≈ hermite(copy(transpose(R₀)))[1]
+@test L*V₁ ≈ copy(transpose(p₁))
+@test L*V₂ ≈ copy(transpose(p₂))
 
 # colred
 s = variable("s")
@@ -65,12 +65,12 @@ R,U = colred(p)
 R1,R2 = colred(p, p2)
 @test isapprox(R, R1)
 
-R,U = rowred(p.')
-@test isapprox(R, R₀.')
-@test isapprox(U, U₀.')
-@test isapprox(U*p.', R)
+R,U = rowred(copy(transpose(p)))
+@test isapprox(R, copy(transpose(R₀)))
+@test isapprox(U, copy(transpose(U₀)))
+@test isapprox(U*transpose(p), R)
 
-R1,R2 = rowred(p.', p2.')
+R1,R2 = rowred(copy(transpose(p)), copy(transpose(p2)))
 @test isapprox(R, R1)
 
 # example 2 from "A Fortran 77 package for column reduction of polynomial matrices" Geurts, A.J. Praagman, C., 1998
@@ -90,8 +90,8 @@ p = PolyMatrix([s^3+s^2 ϵ*s+1 one(s); 2s^2 -one(s) -one(s); 3s^2 one(s) one(s)]
 R,U = colred(p)
 @test isapprox(p*U, R)
 
-R,U = rowred(p.')
-@test isapprox(U*p.', R)
+R,U = rowred(copy(transpose(p)))
+@test isapprox(U*transpose(p)), R)
 
 # example 4 from "A Fortran 77 package for column reduction of polynomial matrices" Geurts, A.J. Praagman, C., 1998
 ϵ = e-8
@@ -116,7 +116,7 @@ rmfd = vcat(Dᵣ,Nᵣ)
 lmfd = hcat(-Nₗ, Dₗ)
 
 # verify that example is correct.
-@test vecnorm(lmfd*rmfd) ≈ 0
+@test norm(lmfd*rmfd) ≈ 0
 
 L,U = ltriang(lmfd)
 
@@ -133,7 +133,7 @@ N₀ = Nᵣ*U
 @test isapprox(Dₕ,D₀)
 @test isapprox(Nₕ,N₀)
 
-@test vecnorm(lmfd*vcat(Dₕ,Nₕ)) < 1e-12
+@test norm(lmfd*vcat(Dₕ,Nₕ)) < 1e-12
 
 rmfd2 = vcat(-Dᵣ,Nᵣ)
 R,U = rtriang(rmfd2,false)
@@ -145,7 +145,7 @@ D = U[3:4,3:4]
 # try to get back rfd from obtained lfd
 lmfd2 = hcat(-N,D)
 
-@test vecnorm(lmfd2*rmfd) < 1e-14
+@test norm(lmfd2*rmfd) < 1e-14
 L,U = ltriang(lmfd2)
 
 N = U[3:4,3:4]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PolynomialMatrices
 using Test
 using Polynomials
+using LinearAlgebra
 
 include("type.jl")
 include("methods.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using PolynomialMatrices
-using Base.Test
+using Test
 using Polynomials
 
 include("type.jl")

--- a/test/type.jl
+++ b/test/type.jl
@@ -18,7 +18,7 @@ degreepm2 = 8
 ny  = 2
 nu  = 2
 A   = randn(ny*(degreepm2+1),nu)
-B   = eye(Float64,2)
+B   = Matrix{Float64}(I,2,2)
 
 @test_throws DomainError PolyMatrix(A, (5,nu))
 @test_throws DomainError PolyMatrix(A, (ny,3))


### PR DESCRIPTION
Almost complete. At least the `PolynomialMatrices` package can now be imported (`using`) into Julia v1 (actually tested for Julia v1.2) and the examples can be run. Most tests OK but still some problems remain (detected but not yet solved is a problem with `_ltriang()` - perhaps it should be easy). Certainly many more problems are still hidden but the package can certainly be declared as Julia v1 compatible.